### PR TITLE
Make System Updater notifications fixed with reboot channel non-blockable

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -10,9 +10,17 @@ android_app {
     platform_apis: true,
     privileged: true,
     required: [
+        "etc_default-permissions_app.seamlessupdate.client.xml",
         "etc_permissions_app.seamlessupdate.client.xml",
         "etc_sysconfig_app.seamlessupdate.client.xml",
     ]
+}
+
+prebuilt_etc {
+    name: "etc_default-permissions_app.seamlessupdate.client.xml",
+    src: "etc/default-permissions/app.seamlessupdate.client.xml",
+    sub_dir: "default-permissions",
+    filename_from_src: true,
 }
 
 prebuilt_etc {

--- a/etc/default-permissions/app.seamlessupdate.client.xml
+++ b/etc/default-permissions/app.seamlessupdate.client.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<exceptions>
+    <exception package="app.seamlessupdate.client">
+        <permission name="android.permission.POST_NOTIFICATIONS" fixed="true"/>
+    </exception>
+</exceptions>

--- a/src/app/seamlessupdate/client/NotificationHandler.java
+++ b/src/app/seamlessupdate/client/NotificationHandler.java
@@ -44,20 +44,27 @@ public class NotificationHandler {
 
         final List<NotificationChannel> channels = new ArrayList<>();
 
-        channels.add(new NotificationChannel(NOTIFICATION_CHANNEL_ID_PROGRESS,
-                service.getString(R.string.notification_channel_progress), IMPORTANCE_LOW));
+        final NotificationChannel progress = new NotificationChannel(NOTIFICATION_CHANNEL_ID_PROGRESS,
+                service.getString(R.string.notification_channel_progress), IMPORTANCE_LOW);
+        progress.setBlockable(true);
+        channels.add(progress);
 
         final NotificationChannel reboot = new NotificationChannel(NOTIFICATION_CHANNEL_ID_REBOOT,
                 service.getString(R.string.notification_channel_reboot), IMPORTANCE_HIGH);
         reboot.enableLights(true);
         reboot.enableVibration(true);
+        reboot.setBlockable(false);
         channels.add(reboot);
 
-        channels.add(new NotificationChannel(NOTIFICATION_CHANNEL_ID_FAILURE,
-                service.getString(R.string.notification_channel_failure), IMPORTANCE_LOW));
+        final NotificationChannel failure = new NotificationChannel(NOTIFICATION_CHANNEL_ID_FAILURE,
+                service.getString(R.string.notification_channel_failure), IMPORTANCE_LOW);
+        failure.setBlockable(true);
+        channels.add(failure);
 
-        channels.add(new NotificationChannel(NOTIFICATION_CHANNEL_ID_UPDATED,
-                service.getString(R.string.notification_channel_updated), IMPORTANCE_MIN));
+        final NotificationChannel updated = new NotificationChannel(NOTIFICATION_CHANNEL_ID_UPDATED,
+                service.getString(R.string.notification_channel_updated), IMPORTANCE_MIN);
+        updated.setBlockable(true);
+        channels.add(updated);
 
         notificationManager.createNotificationChannels(channels);
     }


### PR DESCRIPTION
**Description:**

This PR improves System Updater behavior by making its notifications fixed and marking only the reboot notification channel as non-blockable. This prevents users from accidentally disabling all update-related notifications when only intending to silence specific ones like “Already up-to-date” or update progress.

This approach follows the model used in other system apps (e.g. [GmsCompat](https://github.com/GrapheneOS/platform_packages_apps_GmsCompat/)), where notifications are fixed but individual channels can still be selectively disabled — except for the critical ones.

**Changes:**

- System Updater’s notifications are now marked as fixed, so they cannot be disabled entirely.
- Only the reboot notification channel is marked non-blockable.
- All other channels remain explicitly blockable, allowing users to silence non-critical notifications.

**Testing:**

Tested on Pixel 6a with 2025032100 release to ensure:
- Reboot notification remains active and cannot be disabled.
- Progress and up-to-date notifications can be turned off by the user.
- No regressions or changes in expected update behavior.

A screenshot of the System Updater notification settings demonstrating these blockable channels can be found here: [https://drive.google.com/file/d/1zSP1BJ0cy8xkx4vGpsbB1FOwBo3dUT2Y/view?usp=sharing](https://drive.google.com/file/d/1zSP1BJ0cy8xkx4vGpsbB1FOwBo3dUT2Y/view?usp=sharing)

Additionally, a recording showing a user explicitly disabling the download progress notification channel is available here: [https://drive.google.com/file/d/1b4pK4d75j0OBjryucCVCpNsLoANjmrZK/view?usp=sharing](https://drive.google.com/file/d/1b4pK4d75j0OBjryucCVCpNsLoANjmrZK/view?usp=sharing)

**Expected Behavior:**

- Reboot alerts are always delivered to ensure required action is taken.
- Users can still disable non-critical update notifications like the download progress.

These notification changes may make the alert behavior in #(102) unnecessary, since users will no longer be able to disable the reboot notification. However, I believe the alerts for mismatched network in #(105) is still relevant and worth reviewing independently.

Resolves: #(101), #(102)